### PR TITLE
fix(fieldTemplates): use labels instead of metadata

### DIFF
--- a/extensions/height/src/hooks/useFieldTemplates.ts
+++ b/extensions/height/src/hooks/useFieldTemplates.ts
@@ -15,13 +15,13 @@ export default function useFieldTemplates({ options }: Props = {}) {
   const { statuses, prioritiesObj, priorities, startDate, dueDate } = useMemo(() => {
     const statuses = data?.list
       ?.find((fieldTemplate) => fieldTemplate?.standardType?.toLowerCase() === "status")
-      ?.metadata?.options?.filter((option) => !option?.deleted && !option?.archived);
+      ?.labels?.filter((label) => !label?.deleted && !label?.archived);
 
     const prioritiesObj = data?.list?.find(
       (fieldTemplate) => fieldTemplate?.standardType?.toLowerCase() === "priority"
     );
 
-    const priorities = prioritiesObj?.metadata?.options?.filter((option) => !option?.deleted && !option?.archived);
+    const priorities = prioritiesObj?.labels?.filter((label) => !label?.deleted && !label?.archived);
 
     const startDate = data?.list?.find((fieldTemplate) => fieldTemplate?.standardType === "startDate");
 


### PR DESCRIPTION
## Description

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [ ] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [ ] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [ ] I checked that files in the `assets` folder are used by the extension itself
- [ ] I checked that assets used by the `README` are placed outside of the `metadata` folder
